### PR TITLE
Remove node 4 from appveyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 # Test against the latest version of this Node.js version
 environment:
   matrix:
-    - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
 


### PR DESCRIPTION
Node 4 was removed from the travis pipeline and this removes it from the appveyor pipeline. It was causing some flakey tests because some of addons have deprecated node 4 support.