### PR TITLE
🐛 Fix meta module

### DIFF
--- a/addon-test-support/@percy/ember/index.js
+++ b/addon-test-support/@percy/ember/index.js
@@ -1,16 +1,16 @@
 import utils from '@percy/sdk-utils';
 import { VERSION as emberVersion } from '@ember/version';
-import { VERSION as sdkVersion, PERCY_SERVER_ADDRESS } from '@percy/ember/meta';
+import SDKENV from '@percy/ember/env';
 
 // Collect client and environment information
-const CLIENT_INFO = `@percy/ember/${sdkVersion}`;
+const CLIENT_INFO = `@percy/ember/${SDKENV.VERSION}`;
 const ENV_INFO = [`ember/${emberVersion}`];
 
 if (window.QUnit) ENV_INFO.push(`qunit/${window.QUnit.version}`);
 if (window.mocha) ENV_INFO.push(`mocha/${window.mocha.version}`);
 
 // Maybe set the CLI API address from the environment
-utils.percy.address = PERCY_SERVER_ADDRESS;
+utils.percy.address = SDKENV.PERCY_SERVER_ADDRESS;
 
 // Helper to generate a snapshot name from the test suite
 function generateName(assertOrTestOrName) {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
   },
 
   treeForAddonTestSupport(tree) {
-    let meta = new WriteFile('@percy/ember/meta.js', (
+    let meta = new WriteFile('@percy/ember/env.js', (
       `export default ${JSON.stringify({
         VERSION: pkg.version,
         PERCY_SERVER_ADDRESS: process.env.PERCY_SERVER_ADDRESS

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -62,7 +62,7 @@ module('percySnapshot', hooks => {
     assert.equal(reqs[2][1].name, 'Snapshot 1');
     assert.matches(reqs[2][1].url, /^http:\/\/localhost:7357/);
     assert.matches(reqs[2][1].domSnapshot, /<body class="ember-application"><\/body>/);
-    assert.matches(reqs[2][1].clientInfo, /@percy\/ember\/.+/);
+    assert.matches(reqs[2][1].clientInfo, /@percy\/ember\/\d.+/);
     assert.matches(reqs[2][1].environmentInfo[0], /ember\/.+/);
     assert.matches(reqs[2][1].environmentInfo[1], /qunit\/.+/);
 


### PR DESCRIPTION
## What is this?

Ember AMD modules do not do default interops which means we have to either reference/destructure the default, or export named variables from the virtual `meta` file. I've opted for the former to keep the virtual module simple and renamed it to `env`.