### PR TITLE
Fix installation doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```sh-session
-$ npm install --save-dev @percy/cli @percy/ember@next
+$ npm install --save-dev @percy/cli @percy/ember
 ```
 
 ## Usage


### PR DESCRIPTION
Targeting `next`branch  is not necessary anymore as `3.0.0` is released.
It fixes inconsistency between this README and https://docs.percy.io/docs/ember