### PR TITLE
✅ Use Percy CLI testing mode for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "ember serve",
-    "test": "node node_modules/@percy/sdk-utils/test/server exec -- ember test",
+    "test": "percy exec --testing -- ember test",
     "test:all": "ember try:each",
     "test:types": "tsd"
   },
@@ -44,7 +44,7 @@
     "@ember/test-helpers": "^2.2.5",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@percy/core": "^1.6.4",
+    "@percy/cli": "^1.9.1",
     "@types/mocha": "^9.0.0",
     "@types/qunit": "^2.11.1",
     "babel-eslint": "^10.1.0",

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,50 +1,36 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import helpers from '@percy/sdk-utils/test/client';
+import helpers from '@percy/sdk-utils/test/helpers';
 import percySnapshot from '@percy/ember';
 
 module('percySnapshot', hooks => {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async () => {
-    await helpers.setup();
+    await helpers.setupTest();
     // mock mocha env info
     window.mocha = { version: '1.2.3' };
   });
 
-  hooks.afterEach(async () => {
-    await helpers.teardown();
-  });
-
   test('disables snapshots when the healthcheck fails', async assert => {
-    await helpers.testFailure('/percy/healthcheck');
+    await helpers.test('error', '/percy/healthcheck');
 
     await percySnapshot('Snapshot 1');
     await percySnapshot('Snapshot 2');
 
-    assert.deepEqual(await helpers.getRequests(), [
-      ['/percy/healthcheck']
-    ]);
-
-    assert.deepEqual(helpers.logger.stderr, []);
-    assert.deepEqual(helpers.logger.stdout, [
-      '[percy] Percy is not running, disabling snapshots'
+    assert.contains(await helpers.get('logs'), [
+      'Percy is not running, disabling snapshots'
     ]);
   });
 
   test('disables snapshots when the healthcheck encounters an error', async assert => {
-    await helpers.testError('/percy/healthcheck');
+    await helpers.test('disconnect', '/percy/healthcheck');
 
     await percySnapshot('Snapshot 1');
     await percySnapshot('Snapshot 2');
 
-    assert.deepEqual(await helpers.getRequests(), [
-      ['/percy/healthcheck']
-    ]);
-
-    assert.deepEqual(helpers.logger.stderr, []);
-    assert.deepEqual(helpers.logger.stdout, [
-      '[percy] Percy is not running, disabling snapshots'
+    assert.contains(await helpers.get('logs'), [
+      'Percy is not running, disabling snapshots'
     ]);
   });
 
@@ -52,33 +38,33 @@ module('percySnapshot', hooks => {
     await percySnapshot('Snapshot 1');
     await percySnapshot('Snapshot 2');
 
-    let reqs = await helpers.getRequests();
+    let reqs = await helpers.get('requests');
 
-    assert.equal(reqs[0][0], '/percy/healthcheck');
-    assert.equal(reqs[1][0], '/percy/dom.js');
-    assert.equal(reqs[2][0], '/percy/snapshot');
-    assert.equal(reqs[3][0], '/percy/snapshot');
+    assert.equal(reqs[0].url, '/percy/healthcheck');
+    assert.equal(reqs[1].url, '/percy/dom.js');
+    assert.equal(reqs[2].url, '/percy/snapshot');
+    assert.equal(reqs[3].url, '/percy/snapshot');
 
-    assert.equal(reqs[2][1].name, 'Snapshot 1');
-    assert.matches(reqs[2][1].url, /^http:\/\/localhost:7357/);
-    assert.matches(reqs[2][1].domSnapshot, /<body class="ember-application"><\/body>/);
-    assert.matches(reqs[2][1].clientInfo, /@percy\/ember\/\d.+/);
-    assert.matches(reqs[2][1].environmentInfo[0], /ember\/.+/);
-    assert.matches(reqs[2][1].environmentInfo[1], /qunit\/.+/);
+    assert.equal(reqs[2].body.name, 'Snapshot 1');
+    assert.matches(reqs[2].body.url, /^http:\/\/localhost:7357/);
+    assert.matches(reqs[2].body.domSnapshot, /<body class="ember-application"><\/body>/);
+    assert.matches(reqs[2].body.clientInfo, /@percy\/ember\/\d.+/);
+    assert.matches(reqs[2].body.environmentInfo[0], /ember\/.+/);
+    assert.matches(reqs[2].body.environmentInfo[1], /qunit\/.+/);
 
-    assert.equal(reqs[3][1].name, 'Snapshot 2');
+    assert.equal(reqs[3].body.name, 'Snapshot 2');
   });
 
   test('generates a snapshot name from qunit assert', async assert => {
     await percySnapshot(assert);
-    assert.equal((await helpers.getRequests())[1][1].name, (
+    assert.equal((await helpers.get('requests'))[1].body.name, (
       'percySnapshot | generates a snapshot name from qunit assert'));
   });
 
   test('generates a snapshot name from mocha\'s test', async assert => {
     // mocked since this is not a mocha test
     await percySnapshot({ fullTitle: () => 'Mocha | generated name' });
-    assert.equal((await helpers.getRequests())[1][1].name, 'Mocha | generated name');
+    assert.equal((await helpers.get('requests'))[1].body.name, 'Mocha | generated name');
   });
 
   test('copies scoped attributes to the body element', async assert => {
@@ -88,17 +74,17 @@ module('percySnapshot', hooks => {
 
     await percySnapshot('Snapshot 1');
 
-    assert.matches((await helpers.getRequests())[1][1].domSnapshot, (
+    assert.matches((await helpers.get('requests'))[1].body.domSnapshot, (
       /<body class="ember-application custom-classname" data-test="true"><\/body>/));
   });
 
   test('handles snapshot errors', async assert => {
-    await helpers.testFailure('/percy/snapshot', 'testing');
+    await helpers.test('error', '/percy/snapshot');
 
     await percySnapshot('Snapshot 1');
 
-    assert.deepEqual(helpers.logger.stdout, []);
-    assert.deepEqual(helpers.logger.stderr[0], '[percy] Could not take DOM snapshot "Snapshot 1"');
-    assert.matches(helpers.logger.stderr[1], /^\[percy] Error: testing/);
+    assert.contains(await helpers.get('logs'), [
+      'Could not take DOM snapshot "Snapshot 1"'
+    ]);
   });
 });

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -10,5 +10,11 @@ QUnit.assert.matches = function matches(actual, regex, message) {
   this.pushResult({ result, actual, expected, message });
 };
 
+QUnit.assert.contains = function matches(actual, subset, message) {
+  var result = !!actual && !!subset && subset.every(i => actual.includes(i));
+  var expected = `Array containing [${subset.join(', ')}]`;
+  this.pushResult({ result, actual, expected, message });
+};
+
 setApplication(Application.create(config.APP));
 start({ setupEmberOnerrorValidation: false });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1367,6 +1367,69 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@percy/cli-build@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.9.0.tgz#7fb5059bf9c23df28f7b83120f237d8819de347d"
+  integrity sha512-b6fXWSmNeBZ3eyo8T2APHsorZcOMzYc78ummrHr2xnA80M04gj6edZbn8dPEZofp4CTlp2xqM+wD56CNj8i3mA==
+  dependencies:
+    "@percy/cli-command" "1.9.0"
+
+"@percy/cli-command@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.9.0.tgz#4d073584edd516285b85938ca2335752d52a6dd6"
+  integrity sha512-uoXuE9qlMPT/ePXk+gxAcG8vrOtUvBBndaafzjTJOktex3iMnIt7YYGOH5KV3MUD1JcIP4LXwkC3dK/tipHcRw==
+  dependencies:
+    "@percy/config" "1.9.0"
+    "@percy/core" "1.9.0"
+    "@percy/logger" "1.9.0"
+
+"@percy/cli-config@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.9.0.tgz#0be18a685741a1c333dc1d526945a6de295f73c6"
+  integrity sha512-eqVjQchllNwnDgY5jsrWnD2u28BhkvHXWeu9IbJLRL3neDHemLqfM5W9yMMO9lnAytvHy78FBjsXKdGOVFKTKg==
+  dependencies:
+    "@percy/cli-command" "1.9.0"
+
+"@percy/cli-exec@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.9.0.tgz#57f08ca205d165a1e6884472a903277ada563ae7"
+  integrity sha512-XMO4vgnoteESnVtbGESeB1eibE1LDx9dAa0lIZ/NqRdfIVaRrkIc6gloMzlQYah2+x2+TV41NthTr8B21Qjtcw==
+  dependencies:
+    "@percy/cli-command" "1.9.0"
+    cross-spawn "^7.0.3"
+    which "^2.0.2"
+
+"@percy/cli-snapshot@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.9.0.tgz#5b29f8a5388ddff910a884c04a4e91d331a20550"
+  integrity sha512-ZmhRoncV/yl/58Djj1RGS6yYJtoV93YKSMo5JEmpHMCL6adrteeV46g1u3sqXl2DpREV7wuTpstLi+4cnxdu/g==
+  dependencies:
+    "@percy/cli-command" "1.9.0"
+    yaml "^2.0.0"
+
+"@percy/cli-upload@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.9.0.tgz#cb2ce858732620b8e2c96273798d3d5e0435a842"
+  integrity sha512-F35v1mCMMAg4cH3RPAloLL96G63WAbS/BAc7pACeIMV0TAi5wNq9xueHEULEzKKKFxRVLRiGIpuMlgoIoJVwpw==
+  dependencies:
+    "@percy/cli-command" "1.9.0"
+    fast-glob "^3.2.11"
+    image-size "^1.0.0"
+
+"@percy/cli@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.9.0.tgz#9836d0bb19cb9a756b52adfb5983aee01644e9a0"
+  integrity sha512-IAx//jxgy064/7oQSq4DRrJvCKpHOHBfB4k/21DX9r4J2KSfE9tai+j0uQiiWUIf0nDE2SnRGGFSi0GYy8cWyg==
+  dependencies:
+    "@percy/cli-build" "1.9.0"
+    "@percy/cli-command" "1.9.0"
+    "@percy/cli-config" "1.9.0"
+    "@percy/cli-exec" "1.9.0"
+    "@percy/cli-snapshot" "1.9.0"
+    "@percy/cli-upload" "1.9.0"
+    "@percy/client" "1.9.0"
+    "@percy/logger" "1.9.0"
+
 "@percy/client@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.9.0.tgz#66cadb1e052034d05b3524c2928fda652820e0be"
@@ -1385,7 +1448,7 @@
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@^1.6.4":
+"@percy/core@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.9.0.tgz#665e4dcc1a6516b0a9e9cf2569986c17d2297f3e"
   integrity sha512-9BdqyetwhNUV2AGr65PZfBo5oms6eKzc0hi1yb43Dlb7EY0RRBFq01EXT5J71wEgNqsTk0B7IZ+fBvJwjcbOfw==
@@ -1420,9 +1483,9 @@
   integrity sha512-lnRE8PkvAjSriztJqUkVT+qNhGMjNK+UTL4aUYA/WVAYDLeQmhCRREHHc301X8sFyPIOyQ1KA1WzCEfFuHisaA==
 
 "@percy/sdk-utils@^1.6.4":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.8.0.tgz#8db2aefbb211747f8f622db6daf25b781464a308"
-  integrity sha512-ehyYs7L4MDmqjBAfTHA8wDGrsDHiPrJ5SwMA9g9tT06VUey1JJtjSK30VidoouZQm+Sus9r5lW/K73CQZc3lSg==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.9.1.tgz#daa5d2cb9a2dfb306c094c3b6e1ae3891846f5e4"
+  integrity sha512-/9k1XDYj3xl9xI/cQM1uItIcC8HWpm12sYVAZRMKdddCPc3SAQN93sgVZXF3L4uGgaNiTD1+AtkzuUVSccUpPQ==
 
 "@simple-dom/interface@^1.4.0":
   version "1.4.0"
@@ -6545,6 +6608,13 @@ ignore@^5.1.1, ignore@^5.2.0:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
+image-size@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.2.tgz#d778b6d0ab75b2737c1556dd631652eb963bc486"
+  integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==
+  dependencies:
+    queue "6.0.2"
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz"
@@ -8972,6 +9042,13 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+queue@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
+  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
+  dependencies:
+    inherits "~2.0.3"
 
 quick-lru@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
## What is this?

This PR updates tests to utilize CLI's new testing mode and updated `@percy/sdk-utils` test helpers.