### PR TITLE
💥 Rename Ember specific scope option

### DIFF
--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -87,4 +87,26 @@ module('percySnapshot', hooks => {
       'Could not take DOM snapshot "Snapshot 1"'
     ]);
   });
+
+  module('with an alternate ember-testing scope', hooks => {
+    let $scope;
+
+    hooks.beforeEach(() => {
+      $scope = document.querySelector('#ember-testing');
+      $scope.id = 'testing-container';
+    });
+
+    hooks.afterEach(() => {
+      $scope.id = 'ember-testing';
+    });
+
+    test('uses the alternate scope', async assert => {
+      await percySnapshot('Snapshot 1', {
+        emberTestingScope: '#testing-container'
+      });
+
+      assert.matches((await helpers.get('requests'))[1].body.domSnapshot, (
+        /<body id="testing-container" class="ember-application">/));
+    });
+  });
 });


### PR DESCRIPTION
## What is this?

This SDK compensates for Ember's testing UI by utilizing a `scope` option to dump the contents of that scoped element into the document body. We semi-recently implemented a new type of `scope` option directly in our API that allows scoping snapshots to specific elements in the DOM. With this feature, the two scope options conflict, and this SDK cannot use the new element scoping feature while the Ember testing UI scope feature exists.

Rather than rename the element scoping option for this SDK only, to keep all SDKs consistent we've decided to rename the existing Ember SDK scope option to `emberTestingScope`. Unfortunately, that makes this a breaking change for anybody relying on the old `scope` option behavior. When upgrading, if not renamed, the new `scope` option will take effect and any cropping for that scoped element will be done by our infrastructure and might have unexpected results.