### PR TITLE
:bug: fix shadow DOM serialization

### DIFF
--- a/addon-test-support/@percy/ember/index.js
+++ b/addon-test-support/@percy/ember/index.js
@@ -34,7 +34,7 @@ function scopeDOM(scope, dom) {
   if (!$scoped) return;
 
   // replace body content with scoped content
-  $body.innerHTML = $scoped.innerHTML;
+  $body.replaceChildren(...$scoped.children);
 
   // copy scoped attributes to the body element
   for (let i = 0; i < $scoped.attributes.length; i++) {


### PR DESCRIPTION
* In this PR we're using `replaceChildren` rather than `innerHTML` for the scoped container to preserve the shadow roots. 
* This ideally shouldn't have any side effects.
* This fixes #705 
* Note: This doesn't fix giving shadow host as scope selector.
