### PR TITLE
Add support for pseudoClassEnabledElements in percySnapshot options

### DIFF
--- a/addon-test-support/@percy/ember/index.js
+++ b/addon-test-support/@percy/ember/index.js
@@ -26,6 +26,14 @@ function generateName(assertOrTestOrName) {
   }
 }
 
+// Helper to add pseudoClassEnabledElements that are in .percy.yml file to snapshot options.
+// when options.pseudoClassEnabledElements is not set in percySnapshot options
+function addPseudoClassEnabledELements(options) {
+  if (!options.pseudoClassEnabledElements && utils.percy?.config?.snapshot?.pseudoClassEnabledElements) {
+    options.pseudoClassEnabledElements = utils.percy.config.snapshot.pseudoClassEnabledElements;
+  }
+}
+
 // Helper to scope a DOM snapshot to the ember-testing container to capture the
 // ember application without the testing UI
 function scopeDOM(scope, dom) {
@@ -66,9 +74,7 @@ export default async function percySnapshot(name, {
       eval(await utils.fetchPercyDOM());
     }
 
-    if (!options.pseudoClassEnabledElements && utils.percy?.config?.snapshot?.pseudoClassEnabledElements) {
-      options = { ...options, pseudoClassEnabledElements: utils.percy.config.snapshot.pseudoClassEnabledElements };
-    }
+    addPseudoClassEnabledELements(options);
 
     // Serialize and capture the DOM
     let domSnapshot = window.PercyDOM.serialize({

--- a/addon-test-support/@percy/ember/index.js
+++ b/addon-test-support/@percy/ember/index.js
@@ -66,12 +66,8 @@ export default async function percySnapshot(name, {
       eval(await utils.fetchPercyDOM());
     }
 
-    let pseudoClassEnabledElements;
-    if (Object.hasOwn(options, 'pseudoClassEnabledElements')) {
-      pseudoClassEnabledElements = options.pseudoClassEnabledElements;
-    } else if (utils.percy?.config?.snapshot?.pseudoClassEnabledElements) {
-      pseudoClassEnabledElements = utils.percy.config.snapshot.pseudoClassEnabledElements;
-    }
+    const pseudoClassEnabledElements = options.pseudoClassEnabledElements ||
+    utils.percy?.config?.snapshot?.pseudoClassEnabledElements;
 
     if (pseudoClassEnabledElements) {
       options = { ...options, pseudoClassEnabledElements };

--- a/addon-test-support/@percy/ember/index.js
+++ b/addon-test-support/@percy/ember/index.js
@@ -66,11 +66,8 @@ export default async function percySnapshot(name, {
       eval(await utils.fetchPercyDOM());
     }
 
-    const pseudoClassEnabledElements = options.pseudoClassEnabledElements ||
-    utils.percy?.config?.snapshot?.pseudoClassEnabledElements;
-
-    if (pseudoClassEnabledElements) {
-      options = { ...options, pseudoClassEnabledElements };
+    if(!options.pseudoClassEnabledElements && utils.percy?.config?.snapshot?.pseudoClassEnabledElements){
+      options = { ...options, pseudoClassEnabledElements: utils.percy.config.snapshot.pseudoClassEnabledElements };
     }
 
     // Serialize and capture the DOM

--- a/addon-test-support/@percy/ember/index.js
+++ b/addon-test-support/@percy/ember/index.js
@@ -66,7 +66,7 @@ export default async function percySnapshot(name, {
       eval(await utils.fetchPercyDOM());
     }
 
-    if(!options.pseudoClassEnabledElements && utils.percy?.config?.snapshot?.pseudoClassEnabledElements){
+    if (!options.pseudoClassEnabledElements && utils.percy?.config?.snapshot?.pseudoClassEnabledElements) {
       options = { ...options, pseudoClassEnabledElements: utils.percy.config.snapshot.pseudoClassEnabledElements };
     }
 

--- a/addon-test-support/@percy/ember/index.js
+++ b/addon-test-support/@percy/ember/index.js
@@ -66,6 +66,13 @@ export default async function percySnapshot(name, {
       eval(await utils.fetchPercyDOM());
     }
 
+    const pseudoClassEnabledElements = options.pseudoClassEnabledElements ??
+      utils.percy?.config?.snapshot?.pseudoClassEnabledElements;
+
+    if (pseudoClassEnabledElements) {
+      options = { ...options, pseudoClassEnabledElements };
+    }
+
     // Serialize and capture the DOM
     let domSnapshot = window.PercyDOM.serialize({
       domTransformation: dom => scopeDOM(emberTestingScope, (

--- a/addon-test-support/@percy/ember/index.js
+++ b/addon-test-support/@percy/ember/index.js
@@ -66,8 +66,12 @@ export default async function percySnapshot(name, {
       eval(await utils.fetchPercyDOM());
     }
 
-    const pseudoClassEnabledElements = options.pseudoClassEnabledElements ??
-      utils.percy?.config?.snapshot?.pseudoClassEnabledElements;
+    let pseudoClassEnabledElements;
+    if (Object.hasOwn(options, 'pseudoClassEnabledElements')) {
+      pseudoClassEnabledElements = options.pseudoClassEnabledElements;
+    } else if (utils.percy?.config?.snapshot?.pseudoClassEnabledElements) {
+      pseudoClassEnabledElements = utils.percy.config.snapshot.pseudoClassEnabledElements;
+    }
 
     if (pseudoClassEnabledElements) {
       options = { ...options, pseudoClassEnabledElements };

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -91,10 +91,18 @@ module('percySnapshot', hooks => {
 
   module('with options passed to dom serialize', hooks => {
     let $scope;
+    let savedPseudoClassEnabledElements;
 
     hooks.beforeEach(() => {
       $scope = document.querySelector('#ember-testing');
       $scope.appendChild(document.createElement('canvas'));
+      savedPseudoClassEnabledElements = utils.percy?.config?.snapshot?.pseudoClassEnabledElements;
+    });
+
+    hooks.afterEach(() => {
+      if (utils.percy?.config?.snapshot) {
+        utils.percy.config.snapshot.pseudoClassEnabledElements = savedPseudoClassEnabledElements;
+      }
     });
 
     test("serialize canvas when enableJavascript is not present", async assert => {

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
+import utils from '@percy/sdk-utils';
 import helpers from '@percy/sdk-utils/test/helpers';
 import percySnapshot from '@percy/ember';
 
@@ -115,6 +116,39 @@ module('percySnapshot', hooks => {
       });
       assert.matches((await helpers.get('requests'))[1].body.domSnapshot.html, (
         /<body class="ember-application"><\/body>/));
+    });
+
+    test('uses pseudoClassEnabledElements from percy config when option is not passed', async assert => {
+      await utils.isPercyEnabled();
+      utils.percy.config.snapshot.pseudoClassEnabledElements = {
+        selector: ['#ember-testing']
+      };
+
+      await percySnapshot('Snapshot 1');
+
+      let reqs = await helpers.get('requests');
+      let snapshotReq = reqs.filter(req => req.url === '/percy/snapshot').pop();
+      assert.ok(snapshotReq, 'posts snapshot request');
+      assert.deepEqual(snapshotReq.body.pseudoClassEnabledElements?.selector, ['#ember-testing']);
+    });
+
+    test('prioritizes pseudoClassEnabledElements from percySnapshot options over config', async assert => {
+      await utils.isPercyEnabled();
+      utils.percy.config.snapshot.pseudoClassEnabledElements = {
+        selector: ['.from-config']
+      };
+
+      await percySnapshot('Snapshot 1', {
+        pseudoClassEnabledElements: {
+          selector: ['#ember-testing']
+        }
+      });
+
+      let reqs = await helpers.get('requests');
+      let snapshotReq = reqs.filter(req => req.url === '/percy/snapshot').pop();
+      assert.deepEqual(snapshotReq.body.pseudoClassEnabledElements, {
+        selector: ['#ember-testing']
+      });
     });
   });
 


### PR DESCRIPTION
## Description

This PR adds support for the `pseudoClassEnabledElements` option in `percySnapshot` to allow capturing snapshots with pseudo-class states enabled on specific elements.

## Changes

- **Added** `pseudoClassEnabledElements` option support in `percySnapshot` function
- The option can be passed directly to `percySnapshot` or configured globally via Percy config
- When passed directly, it takes precedence over the global config setting
- Falls back to `utils.percy.config.snapshot.pseudoClassEnabledElements` when not explicitly provided

## Implementation Details

The implementation follows a two-tier configuration approach:
1. Check if `pseudoClassEnabledElements` is passed in the `options` parameter
2. If not provided, fall back to the global Percy config setting
3. Pass the resolved value to the snapshot request

## Testing

Added comprehensive test coverage:
- ✅ Test that global Percy config `pseudoClassEnabledElements` is used when option is not passed
- ✅ Test that explicit `pseudoClassEnabledElements` option takes precedence over global config

### Jira: https://browserstack.atlassian.net/browse/PPLT-5015
