### PR TITLE
chore: prepare v5.0.1-beta.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/ember",
-  "version": "5.0.0",
+  "version": "5.0.1-beta.0",
   "description": "Ember client library for visual testing with Percy",
   "keywords": [
     "ember-addon",
@@ -17,6 +17,9 @@
   },
   "engines": {
     "node": ">= 16"
+  },
+  "publishConfig": {
+    "tag": "beta"
   },
   "scripts": {
     "build": "ember build --environment=production",


### PR DESCRIPTION
## Summary
- Bump version to `5.0.1-beta.0`
- Add `publishConfig.tag: "beta"` so `npm publish` publishes to the `beta` dist-tag instead of `latest`

## Next steps after merge
1. Create a GitHub **pre-release** with tag `v5.0.1-beta.0`
2. This triggers the existing `release.yml` workflow which runs `npm publish`
3. The `publishConfig` ensures it publishes under the `beta` npm tag

Users can then install via:
```
npm install @percy/ember@beta
```

> **Note:** Remember to remove `publishConfig.tag` when preparing a stable release.