### PR TITLE
chore: prepare v5.0.1 stable release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/ember",
-  "version": "5.0.1-beta.0",
+  "version": "5.0.1",
   "description": "Ember client library for visual testing with Percy",
   "keywords": [
     "ember-addon",
@@ -19,7 +19,7 @@
     "node": ">= 16"
   },
   "publishConfig": {
-    "tag": "beta"
+    "tag": "latest"
   },
   "scripts": {
     "build": "ember build --environment=production",


### PR DESCRIPTION
## Summary
- Bumps `package.json` version `5.0.1-beta.0` → `5.0.1`.
- Switches `publishConfig.tag` from `beta` to `latest` so npm publish lands on the default dist-tag.

## Why
Promotes the runtime fix for `pseudoClassEnabledElements` from PR #1133 (PPLT-5013) from beta to stable. The fix has been live as `@percy/ember@5.0.1-beta.0` since 2026-03-24 with no reported issues;

## Customer impact
Salsify (deal blocker, PER-6872) is on `@percy/ember`. With this release, setting `pseudo-class-enabled-elements` in `.percy.yml` will take effect once they upgrade to `5.0.1`.

