### PR TITLE
chore: set publishConfig.tag to beta for 5.0.2-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">= 16"
   },
   "publishConfig": {
-    "tag": "latest"
+    "tag": "beta"
   },
   "scripts": {
     "build": "ember build --environment=production",


### PR DESCRIPTION
The merged release PR (#1157) bumped the version to 5.0.2-beta.0 but left `publishConfig.tag` at `latest`. Without this change, `npm publish` would publish the beta under the `latest` dist-tag.