### PR TITLE
security: validate PERCY_SERVER_ADDRESS to loopback (PER-8681, PER-8682)

### DIFF
--- a/addon-test-support/@percy/ember/index.js
+++ b/addon-test-support/@percy/ember/index.js
@@ -10,8 +10,33 @@ const ENV_INFO = [`ember/${emberVersion}`];
 if (window.QUnit) ENV_INFO.push(`qunit/${window.QUnit.version}`);
 if (window.mocha) ENV_INFO.push(`mocha/${window.mocha.version}`);
 
-// Maybe set the CLI API address from the environment
-utils.percy.address = SDKENV.PERCY_SERVER_ADDRESS;
+// The Percy CLI always runs locally, so its address must resolve to a loopback
+// host. Accepting an arbitrary PERCY_SERVER_ADDRESS would let an attacker who
+// can set it redirect snapshot/healthcheck traffic — and, critically, the
+// @percy/dom bundle that is eval'd below is fetched from this address — to a
+// hostile host, turning the eval into remote code execution in the test browser
+// (CWE-918 / CWE-94 — PER-8681 / PER-8682).
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+function isLoopbackAddress(address) {
+  try {
+    return LOOPBACK_HOSTS.has(new URL(address).hostname.toLowerCase());
+  } catch (e) {
+    return false;
+  }
+}
+
+// Maybe set the CLI API address from the environment (loopback only)
+if (SDKENV.PERCY_SERVER_ADDRESS) {
+  if (isLoopbackAddress(SDKENV.PERCY_SERVER_ADDRESS)) {
+    utils.percy.address = SDKENV.PERCY_SERVER_ADDRESS;
+  } else {
+    utils.logger('ember').warn(
+      `Ignoring non-loopback PERCY_SERVER_ADDRESS "${SDKENV.PERCY_SERVER_ADDRESS}"; ` +
+      'the Percy CLI must run on localhost.'
+    );
+  }
+}
 
 // Helper to generate a snapshot name from the test suite
 function generateName(assertOrTestOrName) {
@@ -69,7 +94,10 @@ export default async function percySnapshot(name, {
   name = generateName(name);
 
   try {
-    // Inject @percy/dom
+    // Inject @percy/dom. fetchPercyDOM() retrieves the bundle from
+    // utils.percy.address, which is now validated to a loopback host at module
+    // load (see above), so this eval only ever executes code served by the
+    // local Percy CLI rather than an attacker-controlled origin (PER-8682).
     if (!window.PercyDOM) {
       // eslint-disable-next-line no-eval
       eval(await utils.fetchPercyDOM());


### PR DESCRIPTION
## Summary
Resolves the two runtime component findings behind the percy-ember chains (deadline 2026-06-21).

| Ticket | CWE | Finding |
|--------|-----|---------|
| [PER-8681](https://browserstack.atlassian.net/browse/PER-8681) | CWE-918 | `PERCY_SERVER_ADDRESS` injected verbatim controls all outbound HTTP targets |
| [PER-8682](https://browserstack.atlassian.net/browse/PER-8682) | CWE-94 | `eval` of network-fetched JS executes arbitrary code in the test browser |

## Root cause (shared)
`addon-test-support/@percy/ember/index.js` set `utils.percy.address = SDKENV.PERCY_SERVER_ADDRESS` with **no validation**. `percySnapshot` then `eval()`s the `@percy/dom` bundle returned by `utils.fetchPercyDOM()` — which is fetched **from that address**. So an attacker-controlled address both redirects all SDK traffic (SSRF) and turns the `eval` into RCE in the test browser.

## Fix
Validate `PERCY_SERVER_ADDRESS` resolves to a **loopback** host (`localhost`/`127.0.0.1`/`::1`) before assigning it; otherwise warn and fall back to the `@percy/sdk-utils` default. The `eval` now only ever executes code served by the **local** Percy CLI.

The `eval` itself is the standard PercyDOM-injection mechanism shared by every Percy SDK and is left in place — this PR secures its **source**, which is the exploitable part. Documented inline.

## Verification
- Loopback logic unit-checked (localhost/127.0.0.1 accepted; `evil.example`, `169.254.169.254` rejected).
- `node --check` passes.

Closes PER-8681, PER-8682. Together with the CI hardening (#1164) this severs the percy-ember supply-chain → runtime chains (PER-8691/8692/8693).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-8681]: https://browserstack.atlassian.net/browse/PER-8681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8682]: https://browserstack.atlassian.net/browse/PER-8682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ