### PR TITLE
test: make canvas serialization assertion attribute-order independent

### DIFF
--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -107,8 +107,11 @@ module('percySnapshot', hooks => {
 
     test("serialize canvas when enableJavascript is not present", async assert => {
       await percySnapshot('Snapshot 1');
+      // the canvas should be replaced by an image with a serialized src;
+      // attribute order varies between @percy/dom versions, so assert each
+      // attribute independently via lookaheads instead of a fixed order
       assert.matches((await helpers.get('requests'))[1].body.domSnapshot.html, (
-        /<body class="ember-application"><img src=".*" data-percy-element-id=".*" data-percy-canvas-serialized="" style="max-width: 100%;"><\/body>/));
+        /<body class="ember-application"><img(?=[^>]* src="[^"]*")(?=[^>]* data-percy-element-id="[^"]*")(?=[^>]* data-percy-canvas-serialized="")(?=[^>]* style="max-width: 100%;")[^>]*><\/body>/));
     });
 
     test("doesn't serialize canvas when enableJavascript is true", async assert => {


### PR DESCRIPTION
## Root cause

The SDK regression for PER-9772 (dispatching `test.yml` with @percy/cli built from current master, 1.32.3-beta.3) failed exactly one test:

`percySnapshot > with options passed to dom serialize: serialize canvas when enableJavascript is not present`

The test asserted the full canvas-replacement `<img>` tag with a **fixed attribute order** (`src` first):

```
/<img src=".*" data-percy-element-id=".*" data-percy-canvas-serialized="" style="max-width: 100%;">/
```

percy/cli#1948 (commit `41034865`, "Adding support for ignoreCanvasSerializationErrors", first shipped in @percy/cli **1.31.10-beta.0**) refactored `serializeCanvas` into a `createAndInsertImageElement` helper that copies the canvas attributes (including `data-percy-element-id`) onto the img **before** setting the serialized `src`, so newer @percy/dom emits:

```
<img data-percy-element-id="..." data-percy-canvas-serialized="" src="http://render.percy.local/__serialized__/....png" style="max-width: 100%;">
```

Same element, same attributes, different order — HTML attribute order is not semantically meaningful, so this is a stale/over-strict test expectation, **not** a @percy/dom regression. This repo's own CI still passes because `yarn.lock` pins @percy/cli 1.31.1, which predates the reorder.

## Fix

Assert each key attribute of the replacement image (`src`, `data-percy-element-id`, `data-percy-canvas-serialized`, the `max-width: 100%` style) via regex lookaheads instead of a fixed-order full-tag match, so the test passes against both old and new @percy/dom output.

## Verification

Ran `yarn test` locally in both modes, 13/13 pass in each:

- **Released CLI** (locked @percy/cli 1.31.1 — old attribute order): 13 pass / 0 fail
- **Linked CLI master** (1.32.3-beta.3 via `yarn build && yarn global:link` + `yarn link` of all @percy packages, matching the workflow_dispatch path in test.yml — new attribute order): 13 pass / 0 fail

Failing run this fixes: https://github.com/percy/percy-ember/actions/runs/28640546960

🤖 Generated with [Claude Code](https://claude.com/claude-code)