### PR TITLE
fix: merge .percy.yml config into serialize options (PER-8053 gap)

### DIFF
--- a/addon-test-support/@percy/ember/index.js
+++ b/addon-test-support/@percy/ember/index.js
@@ -128,12 +128,18 @@ export default async function percySnapshot(name, {
       }
     }
 
+    // PER-8053: deep-merge the global .percy.yml `snapshot` config into the
+    // per-call options (per-call wins at the leaves) so config-only keys like
+    // enableJavaScript reach PercyDOM.serialize — previously only per-call
+    // options were serialized, dropping all config-driven serialize behavior.
+    const mergedOptions = utils.mergeSnapshotOptions(options);
+
     // Serialize and capture the DOM
     let domSnapshot = PercyDOM.serialize({
       domTransformation: dom => scopeDOM(emberTestingScope, (
         domTransformation ? domTransformation(dom) : dom
       )),
-      ...options
+      ...mergedOptions
     });
 
     // Attach readiness diagnostics so the CLI can log timing and pass/fail.

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -138,7 +138,7 @@ module('percySnapshot', hooks => {
     test("removes canvas element when dom transformation is passed", async assert => {
       await percySnapshot('Snapshot 1', {
         domTransformation: (html) => { html.querySelector('canvas')?.remove(); return html; },
-        enable_javascript: true
+        enableJavaScript: true
       });
       assert.matches((await helpers.get('requests'))[1].body.domSnapshot.html, (
         /<body class="ember-application"><\/body>/));

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -92,16 +92,19 @@ module('percySnapshot', hooks => {
   module('with options passed to dom serialize', hooks => {
     let $scope;
     let savedPseudoClassEnabledElements;
+    let savedEnableJavaScript;
 
     hooks.beforeEach(() => {
       $scope = document.querySelector('#ember-testing');
       $scope.appendChild(document.createElement('canvas'));
       savedPseudoClassEnabledElements = utils.percy?.config?.snapshot?.pseudoClassEnabledElements;
+      savedEnableJavaScript = utils.percy?.config?.snapshot?.enableJavaScript;
     });
 
     hooks.afterEach(() => {
       if (utils.percy?.config?.snapshot) {
         utils.percy.config.snapshot.pseudoClassEnabledElements = savedPseudoClassEnabledElements;
+        utils.percy.config.snapshot.enableJavaScript = savedEnableJavaScript;
       }
     });
 
@@ -118,6 +121,18 @@ module('percySnapshot', hooks => {
       await percySnapshot('Snapshot 1', { enableJavaScript: true });
       assert.matches((await helpers.get('requests'))[1].body.domSnapshot.html, (
         /<body class="ember-application"><canvas data-percy-element-id=".*"><\/canvas><\/body>/));     
+    });
+
+    test("applies enableJavaScript from percy config to serialize (PER-8053)", async assert => {
+      // Config-only key (no per-call option) must reach PercyDOM.serialize.
+      // With enableJavaScript on, the canvas is NOT serialized to an <img>.
+      await utils.isPercyEnabled();
+      utils.percy.config.snapshot.enableJavaScript = true;
+
+      await percySnapshot('Snapshot 1');
+
+      assert.matches((await helpers.get('requests'))[1].body.domSnapshot.html, (
+        /<body class="ember-application"><canvas data-percy-element-id=".*"><\/canvas><\/body>/));
     });
 
     test("removes canvas element when dom transformation is passed", async assert => {


### PR DESCRIPTION
## Problem
`percySnapshot` serialized only the **raw per-call options**, so the global `.percy.yml` `snapshot` config never reached `PercyDOM.serialize`. Only `pseudoClassEnabledElements` (special-cased for the POST body) and `readiness` (used only for the readiness gate) were handled — every other config-driven serialize behavior (`enableJavaScript`, `disableShadowDOM`, `reshuffleInvalidTags`, …) was silently dropped. Unlike the other JS SDKs, ember never called `utils.mergeSnapshotOptions`.

Found by a cross-SDK sanity sweep that verifies the exact options handed to `PercyDOM.serialize`. ⚠️ The gap shipped in `v5.0.2-beta.1`; a new beta (`5.0.2-beta.2`) will follow this merge.

## Fix
Deep-merge `config.snapshot` into the per-call options via `utils.mergeSnapshotOptions(options)` (per-call wins at the leaves) right before serialize — the same pattern used by cypress, puppeteer, selenium-js, etc.

Deliberately unchanged:
- **POST body** (`forwardOpts`) still posts raw per-call options — the CLI already has the config and applies it server-side.
- **`pseudoClassEnabledElements`** special-case stays (it feeds the POST body, which the existing tests assert).
- **readiness** handling is untouched.

## Test
New acceptance test: with `config.snapshot.enableJavaScript = true` and no per-call option, the canvas is **not** serialized to an `<img>` — proving the config-only key reached `PercyDOM.serialize`. Mirrors the existing per-call `enableJavaScript` canvas test.