### PR TITLE
chore: release 5.0.2-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/ember",
-  "version": "5.0.2-beta.1",
+  "version": "5.0.2-beta.2",
   "description": "Ember client library for visual testing with Percy",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Bumps `package.json` to `5.0.2-beta.2` so the config-merge fix (#1178) can publish. `v5.0.2-beta.1` already shipped to npm without the config merge and npm versions are immutable, so the fix goes out as a new pre-release beta.

Follows #1178 (fix: merge .percy.yml config into serialize options).